### PR TITLE
feat: Convert LoginPage to stateful widget and add dynamic login button

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -1,7 +1,16 @@
 import 'package:flutter/material.dart';
 
-class LoginPage extends StatelessWidget {
+class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+
+  String name = "";
+  bool changeButton = false;
 
   @override
   Widget build(BuildContext context) {
@@ -15,7 +24,7 @@ class LoginPage extends StatelessWidget {
               height: 20,
             ),
             Text(
-                'Welcome',
+                'Welcome $name',
               style: TextStyle(
                 fontSize: 32,
                 fontWeight: FontWeight.bold
@@ -33,6 +42,12 @@ class LoginPage extends StatelessWidget {
                       hintText: 'Enter Username',
                       labelText: 'Username'
                     ),
+                    onChanged: (value){
+                      name = value;
+                      setState(() {
+
+                      });
+                    },
                   ),
                   TextFormField(
                     obscureText: true,
@@ -44,21 +59,47 @@ class LoginPage extends StatelessWidget {
                   SizedBox(
                     height: 40,
                   ),
-                  ElevatedButton(
-                    style: TextButton.styleFrom(
-                      minimumSize: Size(150, 40),
-                      backgroundColor: Colors.deepPurple,
-                      foregroundColor: Colors.white,
-                    ),
-                    child: Text('Login'),
-                    onPressed: (){
+                  InkWell(
+                    onTap: () async {
+                      setState(() {
+                        changeButton = true;
+                      });
+                      await Future.delayed(Duration(seconds: 1));
                       Navigator.pushNamed(context, '/home');
                     },
+                    child: AnimatedContainer(
+                      width: changeButton ? 50 : 150,
+                      height: 50,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: Colors.deepPurple,
+                        borderRadius: BorderRadius.circular(changeButton? 50:4)
+                      ),
+                      duration: Duration(seconds: 1),
+                      child: changeButton? Icon(Icons.done,color: Colors.white,):Text(
+                          'Login',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 16
+                        ),
+                      ),
+                    ),
                   )
+                  // ElevatedButton(
+                  //   style: TextButton.styleFrom(
+                  //     minimumSize: Size(150, 40),
+                  //     backgroundColor: Colors.deepPurple,
+                  //     foregroundColor: Colors.white,
+                  //   ),
+                  //   child: Text('Login'),
+                  //   onPressed: (){
+                  //     Navigator.pushNamed(context, '/home');
+                  //   },
+                  // )
                 ],
               ),
             ),
-        
+
           ],
         ),
       ),


### PR DESCRIPTION
This commit refactors the `LoginPage` to be a `StatefulWidget`, enabling dynamic updates based on user interactions. Key changes include:

-   Conversion of `LoginPage` from `StatelessWidget` to `StatefulWidget`.
-   Introduction of `_LoginPageState` to manage the state of the page.
- Added a String name.
-   Added a bool named changeButton
- Added `setState` in `onChanged` of `TextFormField`.
- Added `name` variable in the `Welcome` text.
-   Replaced `ElevatedButton` with `InkWell` and `AnimatedContainer` to create an animated login button.
-   Implemented the `onTap` function of `InkWell` for navigation and state change.
-   Added a 1-second delay using `Future.delayed` for the button animation.
- The button now changes its width, from `150` to `50` and border radius from `4` to `50` after the tap.
- Display `done` icon after the tap.
-   Refactored the login process to be triggered by tapping the animated button, instead of using `ElevatedButton`.