### PR TITLE
feat: Implement form validation in LoginPage

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -11,96 +11,123 @@ class _LoginPageState extends State<LoginPage> {
 
   String name = "";
   bool changeButton = false;
+  final _formKey = GlobalKey<FormState>();
+
+  moveToHome(BuildContext context) async{
+    if(_formKey.currentState == null) return;
+    if(_formKey.currentState!.validate()){
+      setState(() {
+        changeButton = true;
+      });
+      await Future.delayed(Duration(seconds: 1));
+      await Navigator.pushNamed(context, '/home');
+      setState(() {
+        changeButton = false;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
       body: SingleChildScrollView(
-        child: Column(
-          children: [
-            Image.asset('assets/image/login_image.png',fit: BoxFit.cover),
-            SizedBox(
-              height: 20,
-            ),
-            Text(
-                'Welcome $name',
-              style: TextStyle(
-                fontSize: 32,
-                fontWeight: FontWeight.bold
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              Image.asset('assets/image/login_image.png',fit: BoxFit.cover),
+              SizedBox(
+                height: 20,
               ),
-            ),
-            SizedBox(
-              height: 20,
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 32,vertical: 32),
-              child: Column(
-                children: [
-                  TextFormField(
-                    decoration: InputDecoration(
-                      hintText: 'Enter Username',
-                      labelText: 'Username'
-                    ),
-                    onChanged: (value){
-                      name = value;
-                      setState(() {
-
-                      });
-                    },
-                  ),
-                  TextFormField(
-                    obscureText: true,
-                    decoration: InputDecoration(
-                        hintText: 'Enter Password',
-                        labelText: 'Password'
-                    ),
-                  ),
-                  SizedBox(
-                    height: 40,
-                  ),
-                  InkWell(
-                    onTap: () async {
-                      setState(() {
-                        changeButton = true;
-                      });
-                      await Future.delayed(Duration(seconds: 1));
-                      Navigator.pushNamed(context, '/home');
-                    },
-                    child: AnimatedContainer(
-                      width: changeButton ? 50 : 150,
-                      height: 50,
-                      alignment: Alignment.center,
-                      decoration: BoxDecoration(
-                        color: Colors.deepPurple,
-                        borderRadius: BorderRadius.circular(changeButton? 50:4)
+              Text(
+                  'Welcome $name',
+                style: TextStyle(
+                  fontSize: 32,
+                  fontWeight: FontWeight.bold
+                ),
+              ),
+              SizedBox(
+                height: 20,
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 32,vertical: 32),
+                child: Column(
+                  children: [
+                    TextFormField(
+                      decoration: InputDecoration(
+                        hintText: 'Enter Username',
+                        labelText: 'Username'
                       ),
-                      duration: Duration(seconds: 1),
-                      child: changeButton? Icon(Icons.done,color: Colors.white,):Text(
-                          'Login',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 16
+                      validator: (value){
+                        if(value == null || value.isEmpty){
+                          return 'Username cannot be empty';
+                        }
+                        return null;
+                      },
+                      onChanged: (value){
+                        name = value;
+                        setState(() {
+
+                        });
+                      },
+                    ),
+                    TextFormField(
+                      obscureText: true,
+                      decoration: InputDecoration(
+                          hintText: 'Enter Password',
+                          labelText: 'Password'
+                      ),
+                      validator: (value){
+                        if(value == null || value.isEmpty){
+                          return 'Password cannot be empty';
+                        }
+                        else if(value.length<6){
+                          return 'Password length should be atleast 6';
+                        }
+                        return null;
+                      },
+                    ),
+                    SizedBox(
+                      height: 40,
+                    ),
+                    Material(                                                     //this is for button animation(Ripple effects)
+                      color: Colors.deepPurple,
+                      borderRadius: BorderRadius.circular(changeButton? 50:4),
+                      child: InkWell(
+                        onTap: () => moveToHome(context),
+                        child: AnimatedContainer (
+                          width: changeButton ? 50 : 150,
+                          height: 50,
+                          alignment: Alignment.center,
+                          duration: Duration(seconds: 1),
+                          child: changeButton? Icon(Icons.done,color: Colors.white,):Text(
+                              'Login',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 16
+                            ),
+                          ),
                         ),
                       ),
-                    ),
-                  )
-                  // ElevatedButton(
-                  //   style: TextButton.styleFrom(
-                  //     minimumSize: Size(150, 40),
-                  //     backgroundColor: Colors.deepPurple,
-                  //     foregroundColor: Colors.white,
-                  //   ),
-                  //   child: Text('Login'),
-                  //   onPressed: (){
-                  //     Navigator.pushNamed(context, '/home');
-                  //   },
-                  // )
-                ],
+                    )
+                    // ElevatedButton(
+                    //   style: TextButton.styleFrom(
+                    //     minimumSize: Size(150, 40),
+                    //     backgroundColor: Colors.deepPurple,
+                    //     foregroundColor: Colors.white,
+                    //   ),
+                    //   child: Text('Login'),
+                    //   onPressed: (){
+                    //     Navigator.pushNamed(context, '/home');
+                    //   },
+                    // )
+                  ],
+                ),
               ),
-            ),
 
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
This commit enhances the `LoginPage` by adding form validation to the username and password fields. Key changes include:

-   Introduction of `GlobalKey<FormState>` to manage the form's state.
-   Wrapped the `Column` widget in a `Form` widget.
- Added a validator for the Username `TextFormField`
-   Added a validator for the Password `TextFormField` to check emptiness and minimum length of 6.
-   Modified the `moveToHome` function to validate the form before navigating to the home page.
-   Refactored the `onTap` function of `InkWell` to call the `moveToHome` function.
-   Added a `Material` widget to the login button for ripple animation.