### PR TITLE
feat: Load and display product data from JSON

### DIFF
--- a/assets/files/catalog.json
+++ b/assets/files/catalog.json
@@ -1,0 +1,84 @@
+{
+  "products": [
+    {
+      "id": 1,
+      "name": "Wireless Headphones",
+      "desc": "Noise-canceling over-ear headphones with Bluetooth connectivity.",
+      "price": 99.99,
+      "color": "Black",
+      "image": "https://picsum.photos/800"
+    },
+    {
+      "id": 2,
+      "name": "Smartphone",
+      "desc": "Latest 5G smartphone with OLED display and triple-camera setup.",
+      "price": 799.99,
+      "color": "Blue",
+      "image": "https://picsum.photos/800"
+    },
+    {
+      "id": 3,
+      "name": "Gaming Mouse",
+      "desc": "Ergonomic gaming mouse with customizable RGB lighting.",
+      "price": 49.99,
+      "color": "Red",
+      "image": "https://picsum.photos/800"
+    },
+    {
+      "id": 4,
+      "name": "Mechanical Keyboard",
+      "desc": "RGB backlit mechanical keyboard with customizable keys.",
+      "price": 129.99,
+      "color": "White",
+      "image": "https://picsum.photos/800"
+    },
+    {
+      "id": 5,
+      "name": "Smartwatch",
+      "desc": "Water-resistant smartwatch with heart rate and fitness tracking.",
+      "price": 199.99,
+      "color": "Silver",
+      "image": "https://picsum.photos/800"
+    },
+    {
+      "id": 6,
+      "name": "Laptop",
+      "desc": "Powerful laptop with Intel i7 processor and 16GB RAM.",
+      "price": 1099.99,
+      "color": "Gray",
+      "image": "https://picsum.photos/800"
+    },
+    {
+      "id": 7,
+      "name": "Wireless Earbuds",
+      "desc": "True wireless earbuds with noise cancellation and long battery life.",
+      "price": 149.99,
+      "color": "Black",
+      "image": "https://picsum.photos/800"
+    },
+    {
+      "id": 8,
+      "name": "4K Monitor",
+      "desc": "Ultra HD 4K monitor with high refresh rate and IPS panel.",
+      "price": 499.99,
+      "color": "Black",
+      "image": "https://picsum.photos/800"
+    },
+    {
+      "id": 9,
+      "name": "Portable Speaker",
+      "desc": "Bluetooth speaker with deep bass and waterproof design.",
+      "price": 89.99,
+      "color": "Blue",
+      "image": "https://picsum.photos/800"
+    },
+    {
+      "id": 10,
+      "name": "External SSD",
+      "desc": "1TB external SSD with high-speed USB-C connectivity.",
+      "price": 179.99,
+      "color": "Gray",
+      "image": "https://picsum.photos/800"
+    }
+  ]
+}

--- a/lib/models/catalog.dart
+++ b/lib/models/catalog.dart
@@ -1,14 +1,5 @@
 class CatalogModel{
-  static final items = [
-    Item(
-          id: 1,
-          name: "Red Fish",
-          desc: "A vibrant red fish that stands out in any aquarium.",
-          price: 19.99,
-          color: "#FF5733",
-          image: "https://cdn.pixabay.com/photo/2017/08/31/14/40/fish-2700930_960_720.png"
-    )
-  ];
+  static List<Item> items=[];
 }
 
 class Item{
@@ -20,5 +11,25 @@ class Item{
   final String image;
 
   Item({required this.id, required this.name, required this.desc, required this.price, required this.color, required this.image});
+
+  factory Item.fromMap(Map<String, dynamic>map){
+    return Item(
+        id: map['id'],
+        name: map['name'],
+        desc: map['desc'],
+        price: map['price'],
+        color: map['color'],
+        image: map['image'],
+    );
+  }
+
+  toMap() => {
+    "id": id,
+    "name": name,
+    "desc": desc,
+    "price": price,
+    "color": color,
+    "image": image,
+  };
 }
 

--- a/lib/models/post.dart
+++ b/lib/models/post.dart
@@ -1,0 +1,11 @@
+
+
+class Post{
+  final int userId;
+  final int id;
+  final String title;
+  final String body;
+
+  Post({required this.userId,required this.id,required this.title,required this.body});
+
+}

--- a/lib/models/posts.dart
+++ b/lib/models/posts.dart
@@ -1,0 +1,9 @@
+
+import 'package:flutter_days/models/post.dart';
+
+class Posts{
+  final List<Post> posts;
+
+  Posts({required this.posts});
+}
+

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,15 +1,39 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_days/models/catalog.dart';
 import 'package:flutter_days/widgets/drawer.dart';
-
+import 'dart:convert';
 import '../widgets/item_widget.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
 
   @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+
+  @override
+  void initState() {
+    super.initState();
+    loadData();
+  }
+
+  loadData()async{
+    await Future.delayed(Duration(seconds: 2));
+    var catalogJson = await rootBundle.loadString("assets/files/catalog.json");
+    var decodedData = jsonDecode(catalogJson);
+    var productData = decodedData["products"];
+    CatalogModel.items = List.from(productData).map<Item>((item) => Item.fromMap(item)).toList();
+    setState(() {
+
+    });
+}
+
+  @override
   Widget build(BuildContext context) {
-    final dummyList = List.generate(100, (index) => CatalogModel.items[0]);
+    // final dummyList = List.generate(100, (index) => CatalogModel.items[0]);
     return Scaffold(
       appBar: AppBar(
         title: Text('Catalog App'),
@@ -17,14 +41,18 @@ class HomePage extends StatelessWidget {
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: ListView.builder(
-          itemCount: dummyList.length,
+        child: (CatalogModel.items != null && CatalogModel.items.isNotEmpty)
+        ? ListView.builder(
+          itemCount: CatalogModel.items.length,
             itemBuilder: (context, index){
               return ItemWidget(
-                item: dummyList[index],
+                item: CatalogModel.items[index],
               );
             }
-        ),
+        )
+        : Center(
+          child: CircularProgressIndicator(),
+        )
       ),
       drawer: MyDrawer(),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ flutter:
   #   - images/a_dot_ham.jpeg
   assets:
     - assets/image/
+    - assets/files/
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
This commit implements the loading of product data from a local JSON file and displays it in the `HomePage`. Key changes include:

-   Added `catalog.json` to the `assets/files` directory to store product data.
-   Introduced `CatalogModel` to manage product items, now initialized as an empty list.
-   Implemented the `Item` model with a `fromMap` factory constructor and a `toMap` method for JSON serialization.
-   Added `Post` and `Posts` classes for future API data handling.
-   Modified `HomePage` to a `StatefulWidget` to handle data loading.
-   Implemented `loadData()` to load and decode `catalog.json` from assets.
-   Updated `HomePage` to use `ListView.builder` to display the fetched product data.
-   Added a `CircularProgressIndicator` while the data is loading.
-   Updated the `initState` of `_HomePageState` to call `loadData()`.
- Added `asset` in the `pubspec.yaml` file.