### PR TITLE
feat: Implement GridView for displaying catalog items

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -42,14 +42,52 @@ class _HomePageState extends State<HomePage> {
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: (CatalogModel.items != null && CatalogModel.items.isNotEmpty)
-        ? ListView.builder(
-          itemCount: CatalogModel.items.length,
+        ? GridView.builder(
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              mainAxisSpacing: 16,
+              crossAxisSpacing: 16
+            ),
+            itemCount: CatalogModel.items.length,
             itemBuilder: (context, index){
-              return ItemWidget(
-                item: CatalogModel.items[index],
+              final item = CatalogModel.items[index];
+              return Card(
+                clipBehavior: Clip.antiAlias,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10)
+                ),
+                child: GridTile(
+                  header: Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: Colors.deepPurple,
+                      ),
+                      child: Text(item.name, style: TextStyle(color: Colors.white),),
+                  ),
+                  footer: Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.black,
+                    ),
+                    child: Text(
+                      "\$${item.price.toString()}",
+                      style: TextStyle(color: Colors.white),
+                    ),
+                  ),
+                  child: Image.network(item.image),
+                )
               );
             }
         )
+
+        // ListView.builder(
+        //   itemCount: CatalogModel.items.length,
+        //     itemBuilder: (context, index){
+        //       return ItemWidget(
+        //         item: CatalogModel.items[index],
+        //       );
+        //     }
+        // )
         : Center(
           child: CircularProgressIndicator(),
         )


### PR DESCRIPTION
This commit refactors the `HomePage` to use `GridView.builder` instead of `ListView.builder` for displaying catalog items. Key changes include:

-   Replaced `ListView.builder` with `GridView.builder` for a grid layout.
-   Used `SliverGridDelegateWithFixedCrossAxisCount` to configure the grid with two columns.
-   Added `mainAxisSpacing` and `crossAxisSpacing` for spacing between grid items.
- Added `Card`, `GridTile`, `header`, `footer` and `Image.network` for the items.
-   Removed the old `ListView.builder` code, which is commented out for reference.
- Display `CircularProgressIndicator` when the items list is null or empty.